### PR TITLE
메뉴 담기 모달 구현

### DIFF
--- a/client/src/App.module.css
+++ b/client/src/App.module.css
@@ -1,4 +1,5 @@
 .App {
+  position: relative;
   width: 820px;
   height: 1180px;
   margin: 10px auto;

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import style from "./App.module.css";
 import CategoryTab from "./components/CategoryTab";
 import MenuList from "./components/MenuList";
+import CartAdditionModal from "./components/CartAdditionModal";
 
 interface Beverage {
   category: string;
@@ -11,6 +12,7 @@ interface Beverage {
 export default function App() {
   const [beverages, setBeverages] = useState<Beverage[]>([]);
   const [currentCategoryIndex, setCurrentCategoryIndex] = useState(0);
+  const [isCartAdditionModalOpen, setIsCartAdditionModalOpen] = useState(false);
 
   const categories = beverages.map((beverage) => beverage.category) ?? [];
   const currentMenus = beverages[currentCategoryIndex]?.menus ?? [];
@@ -42,6 +44,14 @@ export default function App() {
     setCurrentCategoryIndex(index);
   };
 
+  const handleMenuItemClick = () => {
+    setIsCartAdditionModalOpen(true);
+  };
+
+  const handleBackdropClick = () => {
+    setIsCartAdditionModalOpen(false);
+  };
+
   return (
     <div className={style.App}>
       <CategoryTab //
@@ -49,7 +59,8 @@ export default function App() {
         currentCategoryIndex={currentCategoryIndex}
         handleCategoryChange={handleCategoryChange}
       />
-      <MenuList key={currentCategoryIndex} menus={currentMenus} />
+      <MenuList key={currentCategoryIndex} menus={currentMenus} handleMenuItemClick={handleMenuItemClick} />
+      {isCartAdditionModalOpen && <CartAdditionModal handleBackdropClick={handleBackdropClick}/>}
     </div>
   );
 }

--- a/client/src/components/CartAdditionModal.module.css
+++ b/client/src/components/CartAdditionModal.module.css
@@ -1,0 +1,22 @@
+.ModalContainer {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+}
+
+.Backdrop {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.Modal {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 70%;
+  height: 50%;
+  transform: translate(-50%, -50%);
+  background-color: white;
+}

--- a/client/src/components/CartAdditionModal.tsx
+++ b/client/src/components/CartAdditionModal.tsx
@@ -1,0 +1,14 @@
+import style from "./CartAdditionModal.module.css";
+
+interface CartAdditionModalProps {
+  handleBackdropClick: () => void;
+}
+
+export default function CartAdditionModal({handleBackdropClick}: CartAdditionModalProps) {
+  return (
+    <div className={style.ModalContainer}>
+      <div className={style.Backdrop} onClick={handleBackdropClick}></div>
+      <div className={style.Modal}></div>
+    </div>
+  );
+}

--- a/client/src/components/MenuItem.module.css
+++ b/client/src/components/MenuItem.module.css
@@ -3,3 +3,7 @@
   flex-direction: column;
   text-align: center;
 }
+
+.MenuItem:hover {
+  cursor: pointer;
+}

--- a/client/src/components/MenuItem.tsx
+++ b/client/src/components/MenuItem.tsx
@@ -2,11 +2,12 @@ import style from "./MenuItem.module.css";
 
 interface MenuProps {
   menu: Menu;
+  handleMenuItemClick: () => void;
 }
 
-export default function MenuItem({ menu }: MenuProps) {
+export default function MenuItem({ menu, handleMenuItemClick }: MenuProps) {
   return (
-    <li className={style.MenuItem}>
+    <li className={style.MenuItem} onClick={handleMenuItemClick}>
       <img src={menu.src} alt={menu.name} />
       <span>{menu.name}</span>
       <span>{menu.price}</span>

--- a/client/src/components/MenuList.tsx
+++ b/client/src/components/MenuList.tsx
@@ -3,14 +3,15 @@ import style from "./MenuList.module.css";
 
 interface MenuListProps {
   menus: Menu[];
+  handleMenuItemClick: () => void;
 }
 
-export default function MenuList({ menus }: MenuListProps) {
+export default function MenuList({ menus, handleMenuItemClick }: MenuListProps) {
   return (
     <main className={`${style.MenuList} ${style.AnimateIn}`}>
       <ul className={style.MenuListContainer}>
         {menus.map((menu) => (
-          <MenuItem key={menu.id} menu={menu} />
+          <MenuItem key={menu.id} menu={menu} handleMenuItemClick={handleMenuItemClick}/>
         ))}
       </ul>
     </main>

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
@@ -20,7 +16,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
## 의도
장바구니에 메뉴를 담기 위해 설정을 하는 `메뉴 담기 모달` 컴포넌트 구현

## 구체적으로 봐야하는 포인트, 세부적인 변경점
- `App` 컴포넌트의 하위 컴포넌트로 `CartAdditionModal` 컴포넌트를 추가
- 개별 메뉴를 클릭하면 `CartAdditionModal` 컴포넌트가 나타나도록 구현
- Backdrop 클릭하면 `CartAdditionModal` 컴포넌트가 사라지도록 구현

## 관련 이슈
#13 
