### PR TITLE
카테고리 서비스, 메뉴 레포지토리 클래스 구현

### DIFF
--- a/be/src/main/java/kr/codesquad/kioskmax/domain/Menu.java
+++ b/be/src/main/java/kr/codesquad/kioskmax/domain/Menu.java
@@ -2,12 +2,26 @@ package kr.codesquad.kioskmax.domain;
 
 import java.time.LocalDateTime;
 
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
 public class Menu {
 
-    Long id;
-    Long categoryId;
-    String name;
-    Long price;
-    String image;
-    LocalDateTime createdDateTime;
+    private final Long id;
+    private final Long categoryId;
+    private final String name;
+    private final Long price;
+    private final String image;
+    private final LocalDateTime createdDateTime;
+
+    @Builder
+    public Menu(Long id, Long categoryId, String name, Long price, String image, LocalDateTime createdDateTime) {
+        this.id = id;
+        this.categoryId = categoryId;
+        this.name = name;
+        this.price = price;
+        this.image = image;
+        this.createdDateTime = createdDateTime;
+    }
 }

--- a/be/src/main/java/kr/codesquad/kioskmax/repository/MenuRepository.java
+++ b/be/src/main/java/kr/codesquad/kioskmax/repository/MenuRepository.java
@@ -1,16 +1,46 @@
 package kr.codesquad.kioskmax.repository;
 
-import kr.codesquad.kioskmax.domain.Menu;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import kr.codesquad.kioskmax.domain.Menu;
 
 @Repository
 public class MenuRepository {
-    NamedParameterJdbcTemplate jdbcTemplate;
+    private final NamedParameterJdbcTemplate jdbcTemplate;
 
-    public List<Menu> findAll() {
-        return null;
+    public MenuRepository(DataSource dataSource) {
+        this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
     }
+
+    public List<Menu> findAllByCategoryId(Long categoryId) {
+        String sql = "SELECT m.id, m.category_id, m.name, m.price, m.image, m.create_at "
+                     + "FROM menu m "
+                     + "LEFT OUTER JOIN (SELECT menu_id, COUNT(menu_id) AS menu_count "
+            + "                            FROM menu_rank "
+            + "                           WHERE sell_at = :now "
+            + "                           GROUP BY menu_id ) mr ON mr.menu_id = m.id "
+                    + "INNER JOIN category c ON c.id = m.category_id "
+                    + "WHERE c.id = :categoryId "
+                    + "ORDER BY menu_count DESC";
+
+        return jdbcTemplate.query(sql, Map.of("categoryId", categoryId, "now", LocalDate.now()), menuMapper);
+    }
+
+    private final RowMapper<Menu> menuMapper = (rs, rowNum) -> Menu.builder()
+        .id(rs.getLong("id"))
+        .categoryId(rs.getLong("category_id"))
+        .name(rs.getString("name"))
+        .price(rs.getLong("price"))
+        .image(rs.getString("image"))
+        .createdDateTime(rs.getTimestamp("create_at").toLocalDateTime())
+        .build();
+
 }

--- a/be/src/main/java/kr/codesquad/kioskmax/service/CategoryService.java
+++ b/be/src/main/java/kr/codesquad/kioskmax/service/CategoryService.java
@@ -1,17 +1,29 @@
 package kr.codesquad.kioskmax.service;
 
-import kr.codesquad.kioskmax.repository.CategoryRepository;
-import kr.codesquad.kioskmax.service.dto.CategoryInformation;
-import org.springframework.stereotype.Service;
-
+import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.stereotype.Service;
+
+import kr.codesquad.kioskmax.repository.CategoryRepository;
+import kr.codesquad.kioskmax.repository.MenuRepository;
+import kr.codesquad.kioskmax.service.dto.CategoryInformation;
+import lombok.RequiredArgsConstructor;
+
 @Service
+@RequiredArgsConstructor
 public class CategoryService {
 
-    CategoryRepository categoryRepository;
+    private final CategoryRepository categoryRepository;
+    private final MenuRepository menuRepository;
 
     public List<CategoryInformation> findAllCategories() {
-        return null;
+        List<CategoryInformation> categoryInformations = new ArrayList<>();
+        categoryRepository.findAll()
+            .forEach(category ->
+                categoryInformations.add(CategoryInformation.of(category,
+                    menuRepository.findAllByCategoryId(category.getId())))
+            );
+        return categoryInformations;
     }
 }

--- a/be/src/main/java/kr/codesquad/kioskmax/service/dto/CategoryInformation.java
+++ b/be/src/main/java/kr/codesquad/kioskmax/service/dto/CategoryInformation.java
@@ -1,6 +1,9 @@
 package kr.codesquad.kioskmax.service.dto;
 
 import java.util.List;
+
+import kr.codesquad.kioskmax.domain.Category;
+import kr.codesquad.kioskmax.domain.Menu;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -18,5 +21,13 @@ public class CategoryInformation {
         this.id = id;
         this.name = name;
         this.menuInformations = menuInformations;
+    }
+
+    public static CategoryInformation of(Category category, List<Menu> menus){
+        return CategoryInformation.builder()
+            .id(category.getId())
+            .name(category.getName())
+            .menuInformations(MenuInformation.from(menus))
+            .build();
     }
 }

--- a/be/src/main/java/kr/codesquad/kioskmax/service/dto/MenuInformation.java
+++ b/be/src/main/java/kr/codesquad/kioskmax/service/dto/MenuInformation.java
@@ -1,5 +1,9 @@
 package kr.codesquad.kioskmax.service.dto;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import kr.codesquad.kioskmax.domain.Menu;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -21,5 +25,21 @@ public class MenuInformation {
         this.name = name;
         this.price = price;
         this.image = image;
+    }
+
+    public static List<MenuInformation> from(List<Menu> menus){
+        return menus.stream()
+            .map(MenuInformation::from)
+            .collect(Collectors.toUnmodifiableList());
+    }
+
+    public static MenuInformation from(Menu menu){
+        return MenuInformation.builder()
+            .id(menu.getId())
+            .categoryId(menu.getCategoryId())
+            .name(menu.getName())
+            .price(menu.getPrice())
+            .image(menu.getImage())
+            .build();
     }
 }

--- a/be/src/main/resources/application.yml
+++ b/be/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
             on-profile: testDB
     datasource:
         driver-class-name: org.h2.Driver
-        url: jdbc:h2:mem:testDB
+        url: jdbc:h2:mem:testDB;MODE=MYSQL
         username: sa
 ---
 spring:

--- a/be/src/test/java/kr/codesquad/kioskmax/repository/MenuRepositoryTest.java
+++ b/be/src/test/java/kr/codesquad/kioskmax/repository/MenuRepositoryTest.java
@@ -1,0 +1,41 @@
+package kr.codesquad.kioskmax.repository;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import kr.codesquad.kioskmax.domain.Menu;
+
+@JdbcTest
+@ActiveProfiles("test")
+class MenuRepositoryTest {
+
+	private final MenuRepository repository;
+
+	@Autowired
+	public MenuRepositoryTest(DataSource dataSource) {
+		this.repository = new MenuRepository(dataSource);
+	}
+
+	@Test
+	@DisplayName("특정 카테고리에 해당하는 메뉴를 판매순으로 정렬한후 모든 메뉴를 반환한다.")
+	void findAll() {
+		//given
+
+		//when
+		List<Menu> actual = repository.findAllByCategoryId(1L);
+
+		//then
+		Assertions.assertThat(actual.size()).isEqualTo(2);
+		Assertions.assertThat(actual.get(0).getName()).isEqualTo("카페모카");
+		Assertions.assertThat(actual.get(1).getName()).isEqualTo("아메리카노");
+
+	}
+}

--- a/be/src/test/java/kr/codesquad/kioskmax/service/CategoryServiceTest.java
+++ b/be/src/test/java/kr/codesquad/kioskmax/service/CategoryServiceTest.java
@@ -1,0 +1,138 @@
+package kr.codesquad.kioskmax.service;
+
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import kr.codesquad.kioskmax.domain.Category;
+import kr.codesquad.kioskmax.domain.Menu;
+import kr.codesquad.kioskmax.repository.CategoryRepository;
+import kr.codesquad.kioskmax.repository.MenuRepository;
+import kr.codesquad.kioskmax.service.dto.CategoryInformation;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryServiceTest {
+
+	@InjectMocks
+	private CategoryService categoryService;
+
+	@Mock
+	private MenuRepository menuRepository;
+
+	@Mock
+	private CategoryRepository categoryRepository;
+
+
+	@Test
+	@DisplayName("DB에서 카테고리별 메뉴를 가져올수 있다. ")
+	void findAllCategories() {
+
+		//given
+		List<Menu> firstCategoryMenus = firstCategoryMenuDummy();
+		List<Menu> secondCategoryMenus = secondCategoryMenuDummy();
+		List<Menu> thirdCategoryMenus = thirdCategoryMenuDummy();
+		List<Category> categories = categoryDummy();
+
+		given(menuRepository.findAllByCategoryId(1L)).willReturn(firstCategoryMenus);
+		given(menuRepository.findAllByCategoryId(2L)).willReturn(secondCategoryMenus);
+		given(menuRepository.findAllByCategoryId(3L)).willReturn(thirdCategoryMenus);
+		given(categoryRepository.findAll()).willReturn(categories);
+
+		//when
+		List<CategoryInformation> actual= categoryService.findAllCategories();
+
+		//then
+		Assertions.assertThat(actual.get(0).getMenuInformations().size()).isEqualTo(2);
+		Assertions.assertThat(actual.get(1).getMenuInformations().size()).isEqualTo(2);
+		Assertions.assertThat(actual.get(2).getMenuInformations().size()).isEqualTo(1);
+	}
+
+	List<Menu> firstCategoryMenuDummy() {
+		Menu menu1 = Menu.builder()
+			.id(1L)
+			.categoryId(1L)
+			.name("Menu1")
+			.price(5000L)
+			.image("menu1.jpg")
+			.createdDateTime(LocalDateTime.now())
+			.build();
+
+		Menu menu2 = Menu.builder()
+			.id(2L)
+			.categoryId(1L)
+			.name("Menu2")
+			.price(6000L)
+			.image("menu2.jpg")
+			.createdDateTime(LocalDateTime.now())
+			.build();
+		return new ArrayList<>(Arrays.asList(menu1,menu2));
+	}
+
+	List<Menu> secondCategoryMenuDummy() {
+			Menu menu3 = Menu.builder()
+				.id(3L)
+				.categoryId(2L)
+				.name("Menu3")
+				.price(7000L)
+				.image("menu3.jpg")
+				.createdDateTime(LocalDateTime.now())
+				.build();
+
+			Menu menu4 = Menu.builder()
+				.id(4L)
+				.categoryId(2L)
+				.name("Menu4")
+				.price(8000L)
+				.image("menu4.jpg")
+				.createdDateTime(LocalDateTime.now())
+				.build();
+		return new ArrayList<>(Arrays.asList(menu3,menu4));
+		}
+
+	List<Menu> thirdCategoryMenuDummy(){
+		Menu menu5 = Menu.builder()
+			.id(5L)
+			.categoryId(3L)
+			.name("Menu5")
+			.price(9000L)
+			.image("menu5.jpg")
+			.createdDateTime(LocalDateTime.now())
+			.build();
+		return new ArrayList<>(Arrays.asList(menu5));
+	}
+
+	List<Category> categoryDummy(){
+		Category category1 = Category.builder()
+			.id(1L)
+			.name("Category1")
+			.createdDateTime(LocalDateTime.now())
+			.build();
+
+		Category category2 = Category.builder()
+			.id(2L)
+			.name("Category2")
+			.createdDateTime(LocalDateTime.now())
+			.build();
+
+		Category category3 = Category.builder()
+			.id(3L)
+			.name("Category3")
+			.createdDateTime(LocalDateTime.now())
+			.build();
+
+		return new ArrayList<>(Arrays.asList(category1,category2,category3));
+	}
+
+
+}

--- a/be/src/test/resources/data.sql
+++ b/be/src/test/resources/data.sql
@@ -13,8 +13,18 @@ insert into menu (category_id, name, price, image, create_at) values (1L, '카�
 insert into menu (category_id, name, price, image, create_at) values (6L, '초코스무디', 4500, 'https://image', now());
 insert into menu (category_id, name, price, image, create_at) values (6L, '밀크스무디', 4000, 'https://image', now());
 insert into menu (category_id, name, price, image, create_at) values (9L, '에비앙', 100000, 'https://image', now());
-insert into menu (category_id, name, price, image, create_at) values (2L, '카페라떼', 10000, 'https://google.com', now());
 insert into menu (category_id, name, price, image, create_at) values (2L, '1등급 우유를 넣은 라떼', 20000, 'https://google.com', now());
 insert into menu (category_id, name, price, image, create_at) values (8L, '김빠진 펩시콜라', 5000, 'https://google.com', now());
 insert into menu (category_id, name, price, image, create_at) values (2L, '카페라떼', 10000, 'https://google.com', now());
 insert into menu (category_id, name, price, image, create_at) values (3L, '보이차', 1000000, 'https://google.com', now());
+
+
+insert into menu_rank (menu_id, sell_at) values (1L, now());
+insert into menu_rank (menu_id, sell_at) values (1L, now());
+insert into menu_rank (menu_id, sell_at) values (1L, now());
+insert into menu_rank (menu_id, sell_at) values (2L, now());
+insert into menu_rank (menu_id, sell_at) values (2L, now());
+insert into menu_rank (menu_id, sell_at) values (2L, now());
+insert into menu_rank (menu_id, sell_at) values (2L, now());
+
+

--- a/be/src/test/resources/schema.sql
+++ b/be/src/test/resources/schema.sql
@@ -41,6 +41,6 @@ CREATE TABLE IF NOT EXISTS category (
 CREATE TABLE IF NOT EXISTS menu_rank (
     id      bigint   NOT NULL auto_increment,
     menu_id bigint   NOT NULL,
-    sell_at datetime NOT NULL,
+    sell_at date NOT NULL,
     PRIMARY KEY(id)
 );


### PR DESCRIPTION
## 의도
비지니스 로직을 처리할수 있는 카테고리 서비스 구현 합니다.
메뉴 레포지토리 클래스 구현 합니다.

## 구체적으로 봐야하는 포인트, 세부적인 변경점
- [x] 1: 카테고리 서비스 구현 (findAllCategories() 를 통해 모든 카테고리와 그에 해당하는 메뉴를 가져온다)
- [x] 2: 메뉴 레포지토리 클래스 구현 (카테고리 아이디에 해당하는 메뉴를 당일 판매량 순으로 정렬하여 가져온다)

