### PR TITLE
메뉴 담기 모달 수량 카운터 컴포넌트 구현

### DIFF
--- a/client/src/components/CartAdditionModal.module.css
+++ b/client/src/components/CartAdditionModal.module.css
@@ -39,6 +39,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  flex: 1;
 }
 
 .MenuItemOption {
@@ -46,4 +47,39 @@
   justify-content: center;
   align-items: center;
   gap: 10px;
+}
+
+.Counter {
+  display: block;
+  width: 35px;
+  height: 35px;
+  border: 1px solid black;
+  border-radius: 100%;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 20px;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.CounterController {
+  width: 35px;
+  height: 35px;
+  font-size: 30px;
+  border: none;
+  border-radius: 50%;
+  background-color: transparent;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.CounterController:hover {
+  cursor: pointer;
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+.CounterController:active {
+  background-color: rgba(0, 0, 0, 0.2);
 }

--- a/client/src/components/CartAdditionModal.tsx
+++ b/client/src/components/CartAdditionModal.tsx
@@ -1,5 +1,6 @@
-import style from "./CartAdditionModal.module.css";
+import { useState } from "react";
 import MenuItem from "./MenuItem";
+import style from "./CartAdditionModal.module.css";
 
 interface CartAdditionModalProps {
   menu: Menu | null;
@@ -7,6 +8,18 @@ interface CartAdditionModalProps {
 }
 
 export default function CartAdditionModal({ menu, handleBackdropClick }: CartAdditionModalProps) {
+  const [quantity, setQuantity] = useState(1);
+
+  const handlePlusButtonClick = () => {
+    setQuantity((q) => q + 1);
+  };
+
+  const handleMinusButtonClick = () => {
+    if (quantity > 1) {
+      setQuantity((q) => q - 1);
+    }
+  };
+
   return (
     <div className={style.ModalContainer}>
       <div className={style.Backdrop} onClick={handleBackdropClick}></div>
@@ -16,11 +29,27 @@ export default function CartAdditionModal({ menu, handleBackdropClick }: CartAdd
           <div className={style.MenuItemOptions}>
             <div className={style.MenuItemOption}></div>
             <div className={style.MenuItemOption}></div>
-            <div className={style.MenuItemOption}></div>
+            <div className={style.MenuItemOption}><QuantityCounter quantity={quantity} handlePlusButtonClick={handlePlusButtonClick} handleMinusButtonClick={handleMinusButtonClick} /></div>
           </div>
         </div>
         {/* Add menu button */}
       </div>
     </div>
+  );
+}
+
+interface QuantityCounterProps {
+  quantity: number;
+  handlePlusButtonClick: () => void;
+  handleMinusButtonClick: () => void;
+}
+
+function QuantityCounter({ quantity, handlePlusButtonClick, handleMinusButtonClick}: QuantityCounterProps) {
+  return (
+    <>
+      <button className={style.CounterController} onClick={handleMinusButtonClick}>-</button>
+      <span className={style.Counter}>{quantity}</span>
+      <button className={style.CounterController} onClick={handlePlusButtonClick}>+</button>
+    </>
   );
 }


### PR DESCRIPTION
## 의도
메뉴 담기 모달에서 담을 개수를 조정하는 수량 카운터 구현

## 구체적으로 봐야하는 포인트, 세부적인 변경점
- `CartAdditionModal`에 메뉴 개수 상태를 저장
- +/- 버튼 클릭 이벤트 핸들러를 props로 `QuantityCounter` 컴포넌트에 내려줌

## 관련 이슈
#18 
