### PR TITLE
fix #31: npm run build bug fix

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -55,7 +55,7 @@ jobs:
               working-directory: ./fe
 
             - name: Build npm
-              run: npm run build
+              run: CI='false' npm run build
               shell: bash
               working-directory: ./fe
 

--- a/be/build.gradle
+++ b/be/build.gradle
@@ -44,10 +44,6 @@ tasks.jar {
 	enabled = false
 }
 
-tasks.jar {
-	enabled = false
-}`
-
 tasks.named('test') {
 	useJUnitPlatform()
 }


### PR DESCRIPTION
## 의도
npm run build bug fix

## 구체적으로 봐야하는 포인트, 세부적인 변경점
- Treating warnings as errors because process.env.CI = true. 에러 수정

## 관련 이슈
#n
