### PR TITLE
장바구니 '전체 취소' 기능 구현

### DIFF
--- a/fe/src/components/Cart.module.css
+++ b/fe/src/components/Cart.module.css
@@ -1,0 +1,75 @@
+.ModalContainer {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+}
+
+.Backdrop {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.15);
+}
+
+.Modal {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 70%;
+  height: 20%;
+  padding: 10%;
+  transform: translate(-50%, -50%);
+  background-color: white;
+}
+
+.CloseButton {
+  position: absolute;
+  top: 0;
+  right: 0;
+  transform: translate(30%, -30%);
+  cursor: pointer;
+  background-color: white;
+  width: 35px;
+  height: 35px;
+  border: 1px solid black;
+  border-radius: 50%;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 20px;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.ModalContent {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+}
+
+.ButtonContainer {
+  width: 100%;
+  display: flex;
+  gap: 10px;
+}
+
+.ConfirmButton {
+  width: 100%;
+  background-color: #e82444;
+  color: white;
+  font-size: 16px;
+  padding: 10px;
+}
+
+.CancelButton {
+  width: 100%;
+  background-color: black;
+  color: white;
+  font-size: 16px;
+  padding: 10px;
+}

--- a/fe/src/components/Cart.tsx
+++ b/fe/src/components/Cart.tsx
@@ -1,14 +1,36 @@
+import { useState } from "react";
+import styles from "./Cart.module.css";
+
 interface CartProps {
   cartItems: CartItem[];
   removeItem: (id: number) => void;
-  removeAllItems: (id: number) => void;
+  removeAllItems: () => void;
   changePage: (path: Path) => void;
 }
 
 export default function Cart({ cartItems, removeItem, removeAllItems, changePage }: CartProps) {
+  const [isRemoveAllItemsModalOpen, setIsRemoveAllItemsModalOpen] = useState(false);
+
+  const openRemoveAllItemsModal = () => {
+    setIsRemoveAllItemsModalOpen(true);
+  };
+
+  const closeRemoveAllItemsModal = () => {
+    setIsRemoveAllItemsModalOpen(false);
+  };
+
   // 결제 수단 고르는 모달
   // 카드결제 눌렀을 때 로딩인디케이터 띄우는 함수
   // 현금결제 눌렀을 때 현금결제 모달 띄우는 함수
+
+  return (
+    <>
+      {isRemoveAllItemsModalOpen && (
+        <RemoveAllItemsConfirmationModal closeModal={closeRemoveAllItemsModal} removeAllItems={removeAllItems} />
+      )}
+      <button onClick={openRemoveAllItemsModal}>전체 취소</button>
+    </>
+  );
 }
 
 interface CartItemProps {
@@ -28,4 +50,51 @@ function CartItem({ id, name, imageSrc, count, price, removeItem }: CartItemProp
   //     <div>{item.count}</div>
   //   </div>
   // );
+}
+
+interface RemoveAllItemsConfirmationModalProps {
+  closeModal: () => void;
+  removeAllItems: () => void;
+}
+
+function RemoveAllItemsConfirmationModal({ closeModal, removeAllItems }: RemoveAllItemsConfirmationModalProps) {
+  const handleConfirmButtonClick = () => {
+    removeAllItems();
+    closeModal();
+  };
+
+  return (
+    <Modal closeModal={closeModal}>
+      <>
+        <div>장바구니에 담긴 상품 모두 삭제하시겠습니까?</div>
+        <div className={styles.ButtonContainer}>
+          <button className={styles.ConfirmButton} onClick={handleConfirmButtonClick}>
+            예
+          </button>
+          <button className={styles.CancelButton} onClick={closeModal}>
+            아니오
+          </button>
+        </div>
+      </>
+    </Modal>
+  );
+}
+
+interface ModalProps {
+  closeModal: () => void;
+  children: JSX.Element;
+}
+
+function Modal({ closeModal, children }: ModalProps) {
+  return (
+    <div className={styles.ModalContainer}>
+      <div className={styles.Backdrop} onClick={closeModal}></div>
+      <div className={styles.Modal}>
+        <div className={styles.CloseButton} onClick={closeModal}>
+          X
+        </div>
+        <div className={styles.ModalContent}>{children}</div>
+      </div>
+    </div>
+  );
 }

--- a/fe/src/components/Main.tsx
+++ b/fe/src/components/Main.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import MenuAddModal from "./MenuAddModal";
 import MenuList from "./MenuList";
 import { AnimationClass } from "../types/constants";
+import Cart from "./Cart";
 
 interface MainProps {
   menus: Menu[];
@@ -41,13 +42,17 @@ export default function Main({ menus, animation, changePage }: MainProps) {
 
   const addMenuToCart = (item: CartItem) => setCartItems(reduceCartItems([...cartItems, item]));
 
+  const removeAllItems = () => {
+    setCartItems([]);
+  };
+
   return (
     <>
       <MenuList menus={menus} handleMenuItemClick={handleMenuItemClick} animation={animation} />
       {isMenuAddModalOpen && selectedMenu && (
         <MenuAddModal menu={selectedMenu} closeModal={closeModal} addMenuToCart={addMenuToCart} />
       )}
-      {/* <Cart /> */}
+      {cartItems.length !== 0 && <Cart removeAllItems={removeAllItems} />}
     </>
   );
 }


### PR DESCRIPTION
## 의도
장바구니 '전체 취소' 기능 구현

## 구체적으로 봐야하는 포인트, 세부적인 변경점
 1. 전체 취소 확인 모달 구현
 2. 확인 시 cartItems 비우기
 3. 장바구니에 음료가 존재하지 않으면 장바구니 영역이 사라진다.

## 관련 이슈
#34
