### PR TITLE
현금 결제 모달 열기 기능

### DIFF
--- a/fe/src/components/Cart.tsx
+++ b/fe/src/components/Cart.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { PaymentSelectionModal } from "./Payment";
+import { CashPaymentModal, PaymentSelectionModal } from "./Payment";
 import styles from "./Cart.module.css";
 import Modal from "./Modal";
 
@@ -13,6 +13,7 @@ interface CartProps {
 export default function Cart({ cartItems, removeItem, removeAllItems, changePage }: CartProps) {
   const [isPaymentModalOpen, setIsPaymentModalOpen] = useState(false);
   const [isRemoveAllItemsModalOpen, setIsRemoveAllItemsModalOpen] = useState(false);
+  const [isCashPaymentModalOpen, setIsCashPaymentModalOpen] = useState(false);
 
   const openRemoveAllItemsModal = () => {
     setIsRemoveAllItemsModalOpen(true);
@@ -47,7 +48,14 @@ export default function Cart({ cartItems, removeItem, removeAllItems, changePage
 
   const selectCardPayment = () => {};
 
-  const selectCashPayment = () => {};
+  const selectCashPayment = () => {
+    closePaymentSelectionModal();
+    setIsCashPaymentModalOpen(true);
+  };
+
+  const closeCashPaymentModal = () => {
+    setIsCashPaymentModalOpen(false);
+  };
 
   return (
     <section className={styles.Cart}>
@@ -65,7 +73,9 @@ export default function Cart({ cartItems, removeItem, removeAllItems, changePage
         <button className={styles.CancelAllButton} onClick={openRemoveAllItemsModal}>
           전체 취소
         </button>
-        <button className={styles.PaymentButton}>결제하기</button>
+        <button className={styles.PaymentButton} onClick={openPaymentSelectionModal}>
+          결제하기
+        </button>
       </div>
       {isRemoveAllItemsModalOpen && (
         <RemoveAllItemsConfirmationModal closeModal={closeRemoveAllItemsModal} removeAllItems={removeAllItems} />
@@ -76,6 +86,9 @@ export default function Cart({ cartItems, removeItem, removeAllItems, changePage
           selectCardPayment={selectCardPayment}
           selectCashPayment={selectCashPayment}
         />
+      )}
+      {isCashPaymentModalOpen && (
+        <CashPaymentModal totalPrice={0} requestPayment={() => {}} closeModal={closeCashPaymentModal} />
       )}
     </section>
   );
@@ -96,7 +109,9 @@ function CartItem({ id, name, imageSrc, count, price, removeItem }: CartItemProp
       <div>{name}</div>
       <div>{price}</div>
       <div className={styles.ItemCount}>{count}</div>
-      <button className={styles.RemoveButton} onClick={() => removeItem(id)}>X</button>
+      <button className={styles.RemoveButton} onClick={() => removeItem(id)}>
+        X
+      </button>
     </div>
   );
 }

--- a/fe/src/components/Cart.tsx
+++ b/fe/src/components/Cart.tsx
@@ -38,6 +38,10 @@ export default function Cart({ cartItems, removeItem, removeAllItems, changePage
     return acc;
   }, []);
 
+  const totalPrice = cartItems.reduce((acc, cartItem) => {
+    return acc + cartItem.price * cartItem.count;
+  }, 0);
+
   const openPaymentSelectionModal = () => {
     setIsPaymentModalOpen(true);
   };
@@ -88,7 +92,7 @@ export default function Cart({ cartItems, removeItem, removeAllItems, changePage
         />
       )}
       {isCashPaymentModalOpen && (
-        <CashPaymentModal totalPrice={0} requestPayment={() => {}} closeModal={closeCashPaymentModal} />
+        <CashPaymentModal totalPrice={totalPrice} requestPayment={() => {}} closeModal={closeCashPaymentModal} />
       )}
     </section>
   );

--- a/fe/src/components/Modal.tsx
+++ b/fe/src/components/Modal.tsx
@@ -1,7 +1,7 @@
 import styles from "./Modal.module.css";
 
 interface ModalProps {
-  closeModal: () => void;
+  closeModal?: () => void;
   children: JSX.Element;
 }
 
@@ -10,9 +10,9 @@ export default function Modal({ closeModal, children }: ModalProps) {
     <div className={styles.ModalContainer}>
       <div className={styles.Backdrop} onClick={closeModal}></div>
       <div className={styles.Modal}>
-        <div className={styles.CloseButton} onClick={closeModal}>
+        {closeModal && <div className={styles.CloseButton} onClick={closeModal}>
           X
-        </div>
+        </div>}
         <div className={styles.ModalContent}>{children}</div>
       </div>
     </div>

--- a/fe/src/components/OptionButton.module.css
+++ b/fe/src/components/OptionButton.module.css
@@ -54,3 +54,14 @@
   justify-content: center;
   cursor: pointer;
 }
+
+.CashInput {
+  background-color: #239290;
+  padding: 10px;
+  border-radius: 10px;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}

--- a/fe/src/components/OptionButton.tsx
+++ b/fe/src/components/OptionButton.tsx
@@ -1,7 +1,7 @@
 import styles from "./OptionButton.module.css";
 
 interface OptionButtonProps {
-  type: "Size" | "Temperature" | "Payment";
+  type: "Size" | "Temperature" | "Payment" | "CashInput";
   text: string;
   isSelected?: boolean;
   onClick: () => void;
@@ -18,6 +18,9 @@ export default function OptionButton({ type, text, isSelected, onClick }: Option
       break;
     case "Payment":
       className = styles.Payment;
+      break;
+    case "CashInput":
+      className = styles.CashInput;
       break;
   }
 

--- a/fe/src/components/Payment.module.css
+++ b/fe/src/components/Payment.module.css
@@ -16,3 +16,46 @@
 .PaymentIcon {
   font-size: 50px;
 }
+
+.InputOptionContainer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.InputOption {
+  box-sizing: border-box;
+  flex: 1 0 45%;
+}
+
+.OrderPriceContainer {
+  margin-top: 15%;
+}
+
+.OrderPrice {
+  display: flex;
+  justify-content: space-between;
+  font-size: 16px;
+  font-weight: bold;
+}
+
+.ConfirmButtonContainer {
+  margin-top: 10%;
+  display: flex;
+  justify-content: space-between;
+}
+
+.ConfirmButton {
+  flex: 0 0 49%;
+  padding: 10px;
+  border-radius: 5px;
+  color: white;
+}
+
+.CashPaymentCancelButton {
+  background-color: rgb(0, 0, 0);
+}
+
+.CashPaymentConfirmButton {
+  background-color: rgb(229, 39, 73);
+}

--- a/fe/src/components/Payment.tsx
+++ b/fe/src/components/Payment.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import Modal from "./Modal";
 import OptionButton from "./OptionButton";
 import styles from "./Payment.module.css";
@@ -39,9 +40,34 @@ export function PaymentSpinner({ requestPayment }: PaymentSpinnerProps) {
 
 interface CashPaymentModalProps {
   totalPrice: number;
+  closeModal: () => void;
   requestPayment: () => void;
 }
 
-export function CashPaymentModal({ totalPrice, requestPayment }: CashPaymentModalProps) {
-  // 투입 얼마했는지 상태
+export function CashPaymentModal({ totalPrice, closeModal, requestPayment }: CashPaymentModalProps) {
+  const [inputAmount, setInputAmount] = useState(0);
+
+  const inputOptions = [100, 500, 1000, 5000, 10000, 50000];
+
+  return (
+    <Modal>
+      <>
+        <div className={styles.InputOptionContainer}>
+          {inputOptions.map((option) => (
+            <div key={option} className={styles.InputOption}>
+              <OptionButton type={"CashInput"} text={option + "원"} onClick={() => {}} />
+            </div>
+          ))}
+        </div>
+        <div className={styles.OrderPriceContainer}>
+          <div className={styles.OrderPrice}>주문 금액 : <span>{totalPrice}원</span></div>
+          <div className={styles.OrderPrice}>투입 금액 : <span>{inputAmount}원</span></div>
+        </div>
+        <div className={styles.ConfirmButtonContainer}>
+          <button className={`${styles.ConfirmButton} ${styles.CashPaymentCancelButton}`}>결제 취소</button>
+          <button className={`${styles.ConfirmButton} ${styles.CashPaymentConfirmButton}`}>현금 결제하기</button>
+        </div>
+      </>
+    </Modal>
+  );
 }


### PR DESCRIPTION
## 의도
결제 방식 선택 모달에서 `현금 결제` 버튼을 클릭했을 때, 현금 결제 모달을 연다.

## 구체적으로 봐야하는 포인트, 세부적인 변경점
- 현금 결제 모달 레이아웃
- 현금 결제 모달에는 모달 컴포넌트의 닫기 아이콘이 불필요해서 제거하기 위해서 ModalProps의 closeModal을 옵셔널로 변경함.
- 현금 결제 모달 열기 외에는 기능이 없습니다.

## 미리보기
https://github.com/kiosk-team-7/kiosk-max/assets/60080167/2665a80f-8765-4577-bd48-a865a1e161a7

## 관련 이슈
#48 
