### PR TITLE
현금 결제 스토리 구현

### DIFF
--- a/fe/src/components/Cart.tsx
+++ b/fe/src/components/Cart.tsx
@@ -1,7 +1,9 @@
-import { useState } from "react";
-import { CashPaymentModal, PaymentSelectionModal } from "./Payment";
+import { useRef, useState } from "react";
+import { PaymentSelectionModal, PaymentSpinner, CashPaymentModal } from "./Payment";
 import styles from "./Cart.module.css";
 import Modal from "./Modal";
+import { API_URL } from "../constants";
+import { PaymentType, Size, Temperature } from "../types/constants";
 
 interface CartProps {
   cartItems: CartItem[];
@@ -10,10 +12,24 @@ interface CartProps {
   changePage: (path: Path) => void;
 }
 
+interface PaymentRequestBody {
+  menus: {
+    id: number;
+    count: number;
+    size: Size;
+    temperature: Temperature;
+  }[];
+  inputAmount: number;
+  totalPrice: number;
+  paymentType: PaymentType;
+}
+
 export default function Cart({ cartItems, removeItem, removeAllItems, changePage }: CartProps) {
   const [isPaymentModalOpen, setIsPaymentModalOpen] = useState(false);
+  const [isIndicatorVisible, setIsIndicatorVisible] = useState(false);
   const [isRemoveAllItemsModalOpen, setIsRemoveAllItemsModalOpen] = useState(false);
   const [isCashPaymentModalOpen, setIsCashPaymentModalOpen] = useState(false);
+  const paymentTypeRef = useRef<PaymentType>();
 
   const openRemoveAllItemsModal = () => {
     setIsRemoveAllItemsModalOpen(true);
@@ -23,8 +39,34 @@ export default function Cart({ cartItems, removeItem, removeAllItems, changePage
     setIsRemoveAllItemsModalOpen(false);
   };
 
-  // 카드결제 눌렀을 때 로딩인디케이터 띄우는 함수
-  // 현금결제 눌렀을 때 현금결제 모달 띄우는 함수
+  const requestPayment = async (inputAmount?: number) => {
+    const body: PaymentRequestBody = {
+      menus: cartItems.map((item) => {
+        return {
+          id: item.id,
+          count: item.count,
+          size: item.options.size,
+          temperature: item.options.temperature,
+        };
+      }),
+      inputAmount: inputAmount || totalPrice,
+      totalPrice,
+      paymentType: paymentTypeRef.current!,
+    };
+
+    const options = {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    };
+
+    const res = await fetch(`${API_URL}/api/orders`, options);
+    const data = await res.json();
+
+    return data;
+  };
 
   const reducedItems = cartItems.reduce((acc: CartItem[], cartItem: CartItem) => {
     const sameItem = acc.find((item) => item.id === cartItem.id);
@@ -50,7 +92,10 @@ export default function Cart({ cartItems, removeItem, removeAllItems, changePage
     setIsPaymentModalOpen(false);
   };
 
-  const selectCardPayment = () => {};
+  const selectCardPayment = () => {
+    paymentTypeRef.current = PaymentType.CARD;
+    setIsIndicatorVisible(true);
+  };
 
   const selectCashPayment = () => {
     closePaymentSelectionModal();
@@ -94,6 +139,7 @@ export default function Cart({ cartItems, removeItem, removeAllItems, changePage
       {isCashPaymentModalOpen && (
         <CashPaymentModal totalPrice={totalPrice} requestPayment={() => {}} closeModal={closeCashPaymentModal} />
       )}
+      {isIndicatorVisible && <PaymentSpinner requestPayment={requestPayment} />}
     </section>
   );
 }

--- a/fe/src/components/Cart.tsx
+++ b/fe/src/components/Cart.tsx
@@ -137,7 +137,7 @@ export default function Cart({ cartItems, removeItem, removeAllItems, changePage
         />
       )}
       {isCashPaymentModalOpen && (
-        <CashPaymentModal totalPrice={totalPrice} requestPayment={() => {}} closeModal={closeCashPaymentModal} />
+        <CashPaymentModal totalPrice={totalPrice} requestPayment={requestPayment} closeModal={closeCashPaymentModal} />
       )}
       {isIndicatorVisible && <PaymentSpinner requestPayment={requestPayment} />}
     </section>

--- a/fe/src/components/Dim.module.css
+++ b/fe/src/components/Dim.module.css
@@ -1,0 +1,15 @@
+.DimContainer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.Dim {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.15);
+  backdrop-filter: blur(1.5px);
+}

--- a/fe/src/components/Dim.tsx
+++ b/fe/src/components/Dim.tsx
@@ -1,0 +1,16 @@
+import styles from "./Dim.module.css";
+
+interface DimProps {
+  children: React.ReactNode;
+  onClick?: () => void;
+}
+
+export default function Dim({ children, onClick }: DimProps) {
+  return (
+    <div className={styles.DimContainer}>
+      <div className={styles.Dim} onClick={onClick}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/fe/src/components/Modal.module.css
+++ b/fe/src/components/Modal.module.css
@@ -1,18 +1,3 @@
-.ModalContainer {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-}
-
-.Backdrop {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.15);
-}
-
 .Modal {
   box-sizing: border-box;
   display: flex;

--- a/fe/src/components/Modal.tsx
+++ b/fe/src/components/Modal.tsx
@@ -1,3 +1,4 @@
+import Dim from "./Dim";
 import styles from "./Modal.module.css";
 
 interface ModalProps {
@@ -7,14 +8,15 @@ interface ModalProps {
 
 export default function Modal({ closeModal, children }: ModalProps) {
   return (
-    <div className={styles.ModalContainer}>
-      <div className={styles.Backdrop} onClick={closeModal}></div>
+    <Dim onClick={closeModal}>
       <div className={styles.Modal}>
-        {closeModal && <div className={styles.CloseButton} onClick={closeModal}>
-          X
-        </div>}
+        {closeModal && (
+          <div className={styles.CloseButton} onClick={closeModal}>
+            X
+          </div>
+        )}
         <div className={styles.ModalContent}>{children}</div>
       </div>
-    </div>
+    </Dim>
   );
 }

--- a/fe/src/components/Payment.module.css
+++ b/fe/src/components/Payment.module.css
@@ -154,4 +154,9 @@
 
 .CashPaymentConfirmButton {
   background-color: rgb(229, 39, 73);
+  opacity: 1;
+}
+
+.CashPaymentConfirmButton:disabled {
+  opacity: 0.35;
 }

--- a/fe/src/components/Payment.module.css
+++ b/fe/src/components/Payment.module.css
@@ -17,6 +17,102 @@
   font-size: 50px;
 }
 
+.SpinnerContent {
+  position: relative;
+  top: 30%;
+  text-align: center;
+  color: #b11334;
+  font-size: 30px;
+}
+
+.Spinner {
+  color: rgb(231, 77, 38);
+  top: 30%;
+  font-size: 90px;
+  text-indent: -9999em;
+  overflow: hidden;
+  width: 1em;
+  height: 1em;
+  border-radius: 50%;
+  margin: 72px auto;
+  position: relative;
+  -webkit-transform: translateZ(0);
+  -ms-transform: translateZ(0);
+  transform: translateZ(0);
+  -webkit-animation: load6 1.7s infinite ease, round 1.7s infinite ease;
+  animation: load6 1.7s infinite ease, round 1.7s infinite ease;
+}
+@-webkit-keyframes load6 {
+  0% {
+    box-shadow: 0 -0.83em 0 -0.4em, 0 -0.83em 0 -0.42em, 0 -0.83em 0 -0.44em, 0 -0.83em 0 -0.46em, 0 -0.83em 0 -0.477em;
+  }
+  5%,
+  95% {
+    box-shadow: 0 -0.83em 0 -0.4em, 0 -0.83em 0 -0.42em, 0 -0.83em 0 -0.44em, 0 -0.83em 0 -0.46em, 0 -0.83em 0 -0.477em;
+  }
+  10%,
+  59% {
+    box-shadow: 0 -0.83em 0 -0.4em, -0.087em -0.825em 0 -0.42em, -0.173em -0.812em 0 -0.44em,
+      -0.256em -0.789em 0 -0.46em, -0.297em -0.775em 0 -0.477em;
+  }
+  20% {
+    box-shadow: 0 -0.83em 0 -0.4em, -0.338em -0.758em 0 -0.42em, -0.555em -0.617em 0 -0.44em,
+      -0.671em -0.488em 0 -0.46em, -0.749em -0.34em 0 -0.477em;
+  }
+  38% {
+    box-shadow: 0 -0.83em 0 -0.4em, -0.377em -0.74em 0 -0.42em, -0.645em -0.522em 0 -0.44em, -0.775em -0.297em 0 -0.46em,
+      -0.82em -0.09em 0 -0.477em;
+  }
+  100% {
+    box-shadow: 0 -0.83em 0 -0.4em, 0 -0.83em 0 -0.42em, 0 -0.83em 0 -0.44em, 0 -0.83em 0 -0.46em, 0 -0.83em 0 -0.477em;
+  }
+}
+@keyframes load6 {
+  0% {
+    box-shadow: 0 -0.83em 0 -0.4em, 0 -0.83em 0 -0.42em, 0 -0.83em 0 -0.44em, 0 -0.83em 0 -0.46em, 0 -0.83em 0 -0.477em;
+  }
+  5%,
+  95% {
+    box-shadow: 0 -0.83em 0 -0.4em, 0 -0.83em 0 -0.42em, 0 -0.83em 0 -0.44em, 0 -0.83em 0 -0.46em, 0 -0.83em 0 -0.477em;
+  }
+  10%,
+  59% {
+    box-shadow: 0 -0.83em 0 -0.4em, -0.087em -0.825em 0 -0.42em, -0.173em -0.812em 0 -0.44em,
+      -0.256em -0.789em 0 -0.46em, -0.297em -0.775em 0 -0.477em;
+  }
+  20% {
+    box-shadow: 0 -0.83em 0 -0.4em, -0.338em -0.758em 0 -0.42em, -0.555em -0.617em 0 -0.44em,
+      -0.671em -0.488em 0 -0.46em, -0.749em -0.34em 0 -0.477em;
+  }
+  38% {
+    box-shadow: 0 -0.83em 0 -0.4em, -0.377em -0.74em 0 -0.42em, -0.645em -0.522em 0 -0.44em, -0.775em -0.297em 0 -0.46em,
+      -0.82em -0.09em 0 -0.477em;
+  }
+  100% {
+    box-shadow: 0 -0.83em 0 -0.4em, 0 -0.83em 0 -0.42em, 0 -0.83em 0 -0.44em, 0 -0.83em 0 -0.46em, 0 -0.83em 0 -0.477em;
+  }
+}
+@-webkit-keyframes round {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+@keyframes round {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
 .InputOptionContainer {
   display: flex;
   flex-wrap: wrap;

--- a/fe/src/components/Payment.tsx
+++ b/fe/src/components/Payment.tsx
@@ -47,7 +47,7 @@ export function PaymentSpinner({ requestPayment }: PaymentSpinnerProps) {
 interface CashPaymentModalProps {
   totalPrice: number;
   closeModal: () => void;
-  requestPayment: () => void;
+  requestPayment: (inputAmount:number) => void;
 }
 
 export function CashPaymentModal({ totalPrice, closeModal, requestPayment }: CashPaymentModalProps) {
@@ -70,6 +70,11 @@ export function CashPaymentModal({ totalPrice, closeModal, requestPayment }: Cas
     setInputAmount((i) => i + amount);
   };
 
+  const handleConfirmButtonClick = () => {
+    setIsPaymentButtonActive(false);
+    requestPayment(inputAmount);
+  };
+
   return (
     <Modal>
       <>
@@ -90,7 +95,7 @@ export function CashPaymentModal({ totalPrice, closeModal, requestPayment }: Cas
         </div>
         <div className={styles.ConfirmButtonContainer}>
           <button className={cancelButtonClassName}>결제 취소</button>
-          <button className={confirmButtonClassName} disabled={!isPaymentButtonActive}>
+          <button className={confirmButtonClassName} onClick={handleConfirmButtonClick} disabled={!isPaymentButtonActive}>
             현금 결제하기
           </button>
         </div>

--- a/fe/src/components/Payment.tsx
+++ b/fe/src/components/Payment.tsx
@@ -94,7 +94,7 @@ export function CashPaymentModal({ totalPrice, closeModal, requestPayment }: Cas
           </div>
         </div>
         <div className={styles.ConfirmButtonContainer}>
-          <button className={cancelButtonClassName}>결제 취소</button>
+          <button className={cancelButtonClassName} onClick={closeModal}>결제 취소</button>
           <button className={confirmButtonClassName} onClick={handleConfirmButtonClick} disabled={!isPaymentButtonActive}>
             현금 결제하기
           </button>

--- a/fe/src/components/Payment.tsx
+++ b/fe/src/components/Payment.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Dim from "./Dim";
 import Modal from "./Modal";
 import OptionButton from "./OptionButton";
@@ -52,8 +52,23 @@ interface CashPaymentModalProps {
 
 export function CashPaymentModal({ totalPrice, closeModal, requestPayment }: CashPaymentModalProps) {
   const [inputAmount, setInputAmount] = useState(0);
+  const [isPaymentButtonActive, setIsPaymentButtonActive] = useState(false);
+
+  useEffect(() => {
+    if (inputAmount >= totalPrice) {
+      setIsPaymentButtonActive(true);
+    } else {
+      setIsPaymentButtonActive(false);
+    }
+  }, [inputAmount]);
 
   const inputOptions = [100, 500, 1000, 5000, 10000, 50000];
+  const cancelButtonClassName = `${styles.ConfirmButton} ${styles.CashPaymentCancelButton}`;
+  const confirmButtonClassName = `${styles.ConfirmButton} ${styles.CashPaymentConfirmButton}`;
+
+  const increaseInputAmount = (amount: number) => {
+    setInputAmount((i) => i + amount);
+  };
 
   return (
     <Modal>
@@ -61,7 +76,7 @@ export function CashPaymentModal({ totalPrice, closeModal, requestPayment }: Cas
         <div className={styles.InputOptionContainer}>
           {inputOptions.map((option) => (
             <div key={option} className={styles.InputOption}>
-              <OptionButton type={"CashInput"} text={option + "원"} onClick={() => {}} />
+              <OptionButton type={"CashInput"} text={option + "원"} onClick={() => increaseInputAmount(option)} />
             </div>
           ))}
         </div>
@@ -74,8 +89,10 @@ export function CashPaymentModal({ totalPrice, closeModal, requestPayment }: Cas
           </div>
         </div>
         <div className={styles.ConfirmButtonContainer}>
-          <button className={`${styles.ConfirmButton} ${styles.CashPaymentCancelButton}`}>결제 취소</button>
-          <button className={`${styles.ConfirmButton} ${styles.CashPaymentConfirmButton}`}>현금 결제하기</button>
+          <button className={cancelButtonClassName}>결제 취소</button>
+          <button className={confirmButtonClassName} disabled={!isPaymentButtonActive}>
+            현금 결제하기
+          </button>
         </div>
       </>
     </Modal>

--- a/fe/src/components/Payment.tsx
+++ b/fe/src/components/Payment.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import Dim from "./Dim";
 import Modal from "./Modal";
 import OptionButton from "./OptionButton";
 import styles from "./Payment.module.css";
@@ -35,7 +36,12 @@ interface PaymentSpinnerProps {
 }
 
 export function PaymentSpinner({ requestPayment }: PaymentSpinnerProps) {
-  return;
+  return (
+    <Dim>
+      <div className={styles.Spinner}></div>
+      <div className={styles.SpinnerContent}>카드 결제중...</div>
+    </Dim>
+  );
 }
 
 interface CashPaymentModalProps {
@@ -60,8 +66,12 @@ export function CashPaymentModal({ totalPrice, closeModal, requestPayment }: Cas
           ))}
         </div>
         <div className={styles.OrderPriceContainer}>
-          <div className={styles.OrderPrice}>주문 금액 : <span>{totalPrice}원</span></div>
-          <div className={styles.OrderPrice}>투입 금액 : <span>{inputAmount}원</span></div>
+          <div className={styles.OrderPrice}>
+            주문 금액 : <span>{totalPrice}원</span>
+          </div>
+          <div className={styles.OrderPrice}>
+            투입 금액 : <span>{inputAmount}원</span>
+          </div>
         </div>
         <div className={styles.ConfirmButtonContainer}>
           <button className={`${styles.ConfirmButton} ${styles.CashPaymentCancelButton}`}>결제 취소</button>


### PR DESCRIPTION
## 의도
투입 금액이 주문 금액 이상이 되면 "현금 결제하기" 버튼을 활성화 한다.
"현금 결제하기" 버튼을 클릭하면 서버로 결제 요청을 하고 버튼을 비활성화한다.
"결제 취소" 버튼을 클릭하면 현금 결제 모달을 닫는다.

## 구체적으로 봐야하는 포인트, 세부적인 변경점
- CashPaymentModaldml useEffect 부분 잘 봐주세요. 혹시 실수한 건 아닌지...
- 결제 취소, 결제하기 버튼 클래스 이름이 길어져서 변수로 뺐는데 맘에 안 드시면 롤백하겠습니다.

## 관련 이슈
#52 
