### PR TITLE
현금 결제 스토리 구현

### DIFF
--- a/fe/src/components/Cart.tsx
+++ b/fe/src/components/Cart.tsx
@@ -137,7 +137,7 @@ export default function Cart({ cartItems, removeItem, removeAllItems, changePage
         />
       )}
       {isCashPaymentModalOpen && (
-        <CashPaymentModal totalPrice={totalPrice} requestPayment={() => {}} closeModal={closeCashPaymentModal} />
+        <CashPaymentModal totalPrice={totalPrice} requestPayment={requestPayment} closeModal={closeCashPaymentModal} />
       )}
       {isIndicatorVisible && <PaymentSpinner requestPayment={requestPayment} />}
     </section>

--- a/fe/src/components/Payment.module.css
+++ b/fe/src/components/Payment.module.css
@@ -154,4 +154,9 @@
 
 .CashPaymentConfirmButton {
   background-color: rgb(229, 39, 73);
+  opacity: 1;
+}
+
+.CashPaymentConfirmButton:disabled {
+  opacity: 0.35;
 }

--- a/fe/src/components/Payment.tsx
+++ b/fe/src/components/Payment.tsx
@@ -47,7 +47,7 @@ export function PaymentSpinner({ requestPayment }: PaymentSpinnerProps) {
 interface CashPaymentModalProps {
   totalPrice: number;
   closeModal: () => void;
-  requestPayment: () => void;
+  requestPayment: (inputAmount:number) => void;
 }
 
 export function CashPaymentModal({ totalPrice, closeModal, requestPayment }: CashPaymentModalProps) {
@@ -70,6 +70,11 @@ export function CashPaymentModal({ totalPrice, closeModal, requestPayment }: Cas
     setInputAmount((i) => i + amount);
   };
 
+  const handleConfirmButtonClick = () => {
+    setIsPaymentButtonActive(false);
+    requestPayment(inputAmount);
+  };
+
   return (
     <Modal>
       <>
@@ -90,7 +95,7 @@ export function CashPaymentModal({ totalPrice, closeModal, requestPayment }: Cas
         </div>
         <div className={styles.ConfirmButtonContainer}>
           <button className={cancelButtonClassName}>결제 취소</button>
-          <button className={confirmButtonClassName} disabled={!isPaymentButtonActive}>
+          <button className={confirmButtonClassName} onClick={handleConfirmButtonClick} disabled={!isPaymentButtonActive}>
             현금 결제하기
           </button>
         </div>

--- a/fe/src/components/Payment.tsx
+++ b/fe/src/components/Payment.tsx
@@ -94,7 +94,7 @@ export function CashPaymentModal({ totalPrice, closeModal, requestPayment }: Cas
           </div>
         </div>
         <div className={styles.ConfirmButtonContainer}>
-          <button className={cancelButtonClassName}>결제 취소</button>
+          <button className={cancelButtonClassName} onClick={closeModal}>결제 취소</button>
           <button className={confirmButtonClassName} onClick={handleConfirmButtonClick} disabled={!isPaymentButtonActive}>
             현금 결제하기
           </button>

--- a/fe/src/components/Payment.tsx
+++ b/fe/src/components/Payment.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Dim from "./Dim";
 import Modal from "./Modal";
 import OptionButton from "./OptionButton";
@@ -52,8 +52,23 @@ interface CashPaymentModalProps {
 
 export function CashPaymentModal({ totalPrice, closeModal, requestPayment }: CashPaymentModalProps) {
   const [inputAmount, setInputAmount] = useState(0);
+  const [isPaymentButtonActive, setIsPaymentButtonActive] = useState(false);
+
+  useEffect(() => {
+    if (inputAmount >= totalPrice) {
+      setIsPaymentButtonActive(true);
+    } else {
+      setIsPaymentButtonActive(false);
+    }
+  }, [inputAmount]);
 
   const inputOptions = [100, 500, 1000, 5000, 10000, 50000];
+  const cancelButtonClassName = `${styles.ConfirmButton} ${styles.CashPaymentCancelButton}`;
+  const confirmButtonClassName = `${styles.ConfirmButton} ${styles.CashPaymentConfirmButton}`;
+
+  const increaseInputAmount = (amount: number) => {
+    setInputAmount((i) => i + amount);
+  };
 
   return (
     <Modal>
@@ -61,7 +76,7 @@ export function CashPaymentModal({ totalPrice, closeModal, requestPayment }: Cas
         <div className={styles.InputOptionContainer}>
           {inputOptions.map((option) => (
             <div key={option} className={styles.InputOption}>
-              <OptionButton type={"CashInput"} text={option + "원"} onClick={() => {}} />
+              <OptionButton type={"CashInput"} text={option + "원"} onClick={() => increaseInputAmount(option)} />
             </div>
           ))}
         </div>
@@ -74,8 +89,10 @@ export function CashPaymentModal({ totalPrice, closeModal, requestPayment }: Cas
           </div>
         </div>
         <div className={styles.ConfirmButtonContainer}>
-          <button className={`${styles.ConfirmButton} ${styles.CashPaymentCancelButton}`}>결제 취소</button>
-          <button className={`${styles.ConfirmButton} ${styles.CashPaymentConfirmButton}`}>현금 결제하기</button>
+          <button className={cancelButtonClassName}>결제 취소</button>
+          <button className={confirmButtonClassName} disabled={!isPaymentButtonActive}>
+            현금 결제하기
+          </button>
         </div>
       </>
     </Modal>


### PR DESCRIPTION
## 의도
투입 금액이 주문 금액 이상이 되면 "현금 결제하기" 버튼을 활성화 한다.
"현금 결제하기" 버튼을 클릭하면 서버로 결제 요청을 하고 버튼을 비활성화한다.
"결제 취소" 버튼을 클릭하면 현금 결제 모달을 닫는다.

## 구체적으로 봐야하는 포인트, 세부적인 변경점
- CashPaymentModaldml useEffect 부분 잘 봐주세요. 혹시 실수한 건 아닌지...
- 결제 취소, 결제하기 버튼 클래스 이름이 길어져서 변수로 뺐는데 맘에 안 드시면 롤백하겠습니다.

## 관련 이슈
#52 