### PR TITLE
카드 결제 결과 스토리 구현

### DIFF
--- a/fe/src/App.tsx
+++ b/fe/src/App.tsx
@@ -1,12 +1,14 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import Home from "./components/Home";
 import Result from "./components/Result";
 
 export default function App() {
   const [currentPath, setCurrentPath] = useState(window.location.pathname);
+  const response = useRef<ResponseBody>();
 
-  const changePage = (path: Path) => {
+  const changePage = (path: Path, res?: ResponseBody) => {
     setCurrentPath(path);
+    response.current = res;
   };
 
   const renderPage = () => {
@@ -14,7 +16,7 @@ export default function App() {
       case "/":
         return <Home changePage={changePage} />;
       case "/result":
-        return <Result changePage={changePage} />;
+        return <Result changePage={changePage} response={response.current} />;
       default:
         return <Home changePage={changePage} />;
     }

--- a/fe/src/components/Cart.tsx
+++ b/fe/src/components/Cart.tsx
@@ -9,7 +9,7 @@ interface CartProps {
   cartItems: CartItem[];
   removeItem: (id: number) => void;
   removeAllItems: () => void;
-  changePage: (path: Path) => void;
+  changePage: (path: Path, response: ResponseBody) => void;
 }
 
 interface PaymentRequestBody {
@@ -39,7 +39,7 @@ export default function Cart({ cartItems, removeItem, removeAllItems, changePage
     setIsRemoveAllItemsModalOpen(false);
   };
 
-  const requestPayment = async (inputAmount?: number) => {
+  const requestPayment = async (inputAmount?: number): Promise<ResponseBody> => {
     const body: PaymentRequestBody = {
       menus: cartItems.map((item) => {
         return {
@@ -63,7 +63,9 @@ export default function Cart({ cartItems, removeItem, removeAllItems, changePage
     };
 
     const res = await fetch(`${API_URL}/api/orders`, options);
-    const data = await res.json();
+
+    const parsedData = await res.json();
+    const data = { status: res.status, body: parsedData };
 
     return data;
   };
@@ -92,9 +94,14 @@ export default function Cart({ cartItems, removeItem, removeAllItems, changePage
     setIsPaymentModalOpen(false);
   };
 
-  const selectCardPayment = () => {
+  const selectCardPayment = async () => {
     paymentTypeRef.current = PaymentType.CARD;
     setIsIndicatorVisible(true);
+
+    const response = await requestPayment();
+
+    setIsIndicatorVisible(false);
+    changePage("/result", response);
   };
 
   const selectCashPayment = () => {
@@ -139,7 +146,7 @@ export default function Cart({ cartItems, removeItem, removeAllItems, changePage
       {isCashPaymentModalOpen && (
         <CashPaymentModal totalPrice={totalPrice} requestPayment={() => {}} closeModal={closeCashPaymentModal} />
       )}
-      {isIndicatorVisible && <PaymentSpinner requestPayment={requestPayment} />}
+      {isIndicatorVisible && <PaymentSpinner />}
     </section>
   );
 }

--- a/fe/src/components/Payment.tsx
+++ b/fe/src/components/Payment.tsx
@@ -31,11 +31,7 @@ export function PaymentSelectionModal({
   );
 }
 
-interface PaymentSpinnerProps {
-  requestPayment: () => void;
-}
-
-export function PaymentSpinner({ requestPayment }: PaymentSpinnerProps) {
+export function PaymentSpinner() {
   return (
     <Dim>
       <div className={styles.Spinner}></div>

--- a/fe/src/components/Result.module.css
+++ b/fe/src/components/Result.module.css
@@ -10,14 +10,14 @@
   gap: 100px;
 }
 
-.ReceiptContainer {
+.Container {
   border: 1px solid black;
   border-radius: 5px;
   padding: 20px;
   line-height: 1.3;
 }
 
-.ReceiptHeader {
+.Header {
   font-size: 24px;
   text-align: center;
   margin: 0px 100px 10px 100px;

--- a/fe/src/components/Result.module.css
+++ b/fe/src/components/Result.module.css
@@ -1,0 +1,47 @@
+.Display {
+  width: 820px;
+  height: 1180px;
+  margin: 10px auto;
+  border: 3px solid black;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 100px;
+}
+
+.ReceiptContainer {
+  border: 1px solid black;
+  border-radius: 5px;
+  padding: 20px;
+  line-height: 1.3;
+}
+
+.ReceiptHeader {
+  font-size: 24px;
+  text-align: center;
+  margin: 0px 100px 10px 100px;
+  margin-bottom: 30px;
+}
+
+.OrderNumber {
+  font-weight: 700;
+}
+
+.OrderMenus {
+  margin-bottom: 30px;
+}
+
+.ReceiptInfo {
+  font-weight: 700;
+}
+
+.ReceiptWarningTextContainer {
+  font-size: 20px;
+  text-align: center;
+}
+
+.ReceiptWarningText {
+  color: #818181;
+  margin-bottom: 20px;
+}

--- a/fe/src/components/Result.tsx
+++ b/fe/src/components/Result.tsx
@@ -1,24 +1,91 @@
+import { useEffect, useState } from "react";
+import styles from "./Result.module.css";
+import { PaymentType } from "../types/constants";
+
 interface ResultPageProps {
   changePage: (path: Path) => void;
+  response: ResponseBody | undefined;
 }
 
-export default function Result({ changePage }: ResultPageProps) {
-  return <></>;
+export default function Result({ changePage, response }: ResultPageProps) {
+  const isSuccess = response?.status === 200;
+
+  return (
+    <>
+      {isSuccess ? (
+        <Receipt changePage={changePage} response={response.body as ReceiptResponseBody} />
+      ) : (
+        <ErrorPage changePage={changePage} />
+      )}
+    </>
+  );
 }
 
 interface ReceiptProps {
-  menus: (Menu & { quantity: number })[];
-  inputAmount: number;
-  totalPrice: number;
-  change: number;
-  paymentType: "현금" | "카드";
   changePage: (path: Path) => void;
+  response: ReceiptResponseBody;
 }
 
-function Receipt(props: ReceiptProps) {}
+function Receipt({ changePage, response }: ReceiptProps) {
+  const [count, setCount] = useState(10);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCount((count) => {
+        return count - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, []);
+
+  useEffect(() => {
+    if (count === 0) {
+      changePage("/");
+    }
+  }, [count]);
+
+  return (
+    <div className={styles.Display}>
+      <main className={styles.ReceiptContainer}>
+        <h2 className={styles.ReceiptHeader}>
+          주문번호 <span className={styles.OrderNumber}>{String(response.orderNumber).padStart(2, "0")}</span>
+        </h2>
+        <ul className={styles.OrderMenus}>
+          {response.menus.map((menu) => {
+            return (
+              <li key={menu.name}>
+                {menu.name} {menu.count}
+              </li>
+            );
+          })}
+        </ul>
+        <div className={styles.ReceiptInfo}>
+          <div>
+            결제방식 :{" "}
+            {response.paymentType === PaymentType.CASH
+              ? "현금"
+              : response.paymentType === PaymentType.CARD
+              ? "카드"
+              : ""}
+          </div>
+          <div>투입금액 : {response.inputAmount}원</div>
+          <div>총 결제금액 : {response.totalPrice}원</div>
+          <div>잔돈 : {response.remain}원</div>
+        </div>
+      </main>
+      <div className={styles.ReceiptWarningTextContainer}>
+        <div className={styles.ReceiptWarningText}>{"(주의 : 이 화면은 10초 뒤에 자동으로 사라집니다)"}</div>
+        <div>{count}초</div>
+      </div>
+    </div>
+  );
+}
 
 interface ErrorPageProps {
   changePage: (path: Path) => void;
 }
 
-function ErrorPage(props: ErrorPageProps) {}
+function ErrorPage(props: ErrorPageProps) {
+  return <></>;
+}

--- a/fe/src/components/Result.tsx
+++ b/fe/src/components/Result.tsx
@@ -27,7 +27,7 @@ export default function Result({ changePage, response }: ResultPageProps) {
     if (count === 0) {
       changePage("/");
     }
-  }, [count]);
+  }, [count, changePage]);
 
   return (
     <>

--- a/fe/src/components/Result.tsx
+++ b/fe/src/components/Result.tsx
@@ -8,26 +8,8 @@ interface ResultPageProps {
 }
 
 export default function Result({ changePage, response }: ResultPageProps) {
-  const isSuccess = response?.status === 200;
-
-  return (
-    <>
-      {isSuccess ? (
-        <Receipt changePage={changePage} response={response.body as ReceiptResponseBody} />
-      ) : (
-        <ErrorPage changePage={changePage} />
-      )}
-    </>
-  );
-}
-
-interface ReceiptProps {
-  changePage: (path: Path) => void;
-  response: ReceiptResponseBody;
-}
-
-function Receipt({ changePage, response }: ReceiptProps) {
   const [count, setCount] = useState(10);
+  const isSuccess = response?.status === 200;
 
   useEffect(() => {
     const timer = setInterval(() => {
@@ -46,46 +28,57 @@ function Receipt({ changePage, response }: ReceiptProps) {
   }, [count]);
 
   return (
-    <div className={styles.Display}>
-      <main className={styles.ReceiptContainer}>
-        <h2 className={styles.ReceiptHeader}>
-          주문번호 <span className={styles.OrderNumber}>{String(response.orderNumber).padStart(2, "0")}</span>
-        </h2>
-        <ul className={styles.OrderMenus}>
-          {response.menus.map((menu) => {
-            return (
-              <li key={menu.name}>
-                {menu.name} {menu.count}
-              </li>
-            );
-          })}
-        </ul>
-        <div className={styles.ReceiptInfo}>
-          <div>
-            결제방식 :{" "}
-            {response.paymentType === PaymentType.CASH
-              ? "현금"
-              : response.paymentType === PaymentType.CARD
-              ? "카드"
-              : ""}
-          </div>
-          <div>투입금액 : {response.inputAmount}원</div>
-          <div>총 결제금액 : {response.totalPrice}원</div>
-          <div>잔돈 : {response.remain}원</div>
+    <>
+      <div className={styles.Display}>
+        <main className={styles.Container}>
+          {isSuccess ? (
+            <Receipt response={response.body as ReceiptResponseBody} />
+          ) : (
+            <ErrorPage response={response?.body as ErrorResponseBody} />
+          )}
+        </main>
+        <div className={styles.ReceiptWarningTextContainer}>
+          <div className={styles.ReceiptWarningText}>{"(주의 : 이 화면은 10초 뒤에 자동으로 사라집니다)"}</div>
+          <div>{count}초</div>
         </div>
-      </main>
-      <div className={styles.ReceiptWarningTextContainer}>
-        <div className={styles.ReceiptWarningText}>{"(주의 : 이 화면은 10초 뒤에 자동으로 사라집니다)"}</div>
-        <div>{count}초</div>
       </div>
-    </div>
+    </>
   );
 }
 
-interface ErrorPageProps {
-  changePage: (path: Path) => void;
+function Receipt({ response }: { response: ReceiptResponseBody }) {
+  return (
+    <>
+      <h2 className={styles.Header}>
+        주문번호 <span className={styles.OrderNumber}>{String(response.orderNumber).padStart(2, "0")}</span>
+      </h2>
+      <ul className={styles.OrderMenus}>
+        {response.menus.map((menu) => {
+          return (
+            <li key={menu.name}>
+              {menu.name} {menu.count}
+            </li>
+          );
+        })}
+      </ul>
+      <div className={styles.ReceiptInfo}>
+        <div>
+          결제방식 :{" "}
+          {response.paymentType === PaymentType.CASH ? "현금" : response.paymentType === PaymentType.CARD ? "카드" : ""}
+        </div>
+        <div>투입금액 : {response.inputAmount}원</div>
+        <div>총 결제금액 : {response.totalPrice}원</div>
+        <div>잔돈 : {response.remain}원</div>
+      </div>
+    </>
+  );
 }
 
-function ErrorPage(props: ErrorPageProps) {
-  return <></>;
+function ErrorPage({ response }: { response: ErrorResponseBody }) {
+  return (
+    <>
+      <h2 className={styles.Header}>결제 실패</h2>
+      <div>{`사유: ${response.message}`}</div>
+    </>
+  );
 }

--- a/fe/src/components/Result.tsx
+++ b/fe/src/components/Result.tsx
@@ -7,8 +7,10 @@ interface ResultPageProps {
   response: ResponseBody | undefined;
 }
 
+const WAITING_TIME = 10;
+
 export default function Result({ changePage, response }: ResultPageProps) {
-  const [count, setCount] = useState(10);
+  const [count, setCount] = useState(WAITING_TIME);
   const isSuccess = response?.status === 200;
 
   useEffect(() => {

--- a/fe/src/types/commons.d.ts
+++ b/fe/src/types/commons.d.ts
@@ -20,3 +20,22 @@ interface CartItem {
   };
   count: number;
 }
+
+interface ResponseBody {
+  status: number;
+  body: ReceiptResponseBody | ErrorResponseBody;
+}
+
+interface ReceiptResponseBody {
+  orderNumber: number;
+  menus: { name: string; count: number }[];
+  paymentType: number;
+  inputAmount: number;
+  totalPrice: number;
+  remain: number;
+}
+
+interface ErrorResponseBody {
+  message: string;
+  statusCode: number;
+}


### PR DESCRIPTION
## 의도
카드 결제 결과 스토리 구현

## 구체적으로 봐야하는 포인트, 세부적인 변경점
 1. 로딩 인디케이터가 닫히고 결과가 나오는대로 페이지를 이동시킨다.
 2. 결제 성공 시 영수증 화면으로 이동한다.
 3. 결제 실패 시 에러 화면으로 이동한다.
 4. 영수증, 에러 화면에서 10초 뒤 자동으로 홈으로 이동한다.

## 관련 이슈
#55
