### PR TITLE
현금 결제 결과 페이지로 이동 기능 구현

### DIFF
--- a/fe/src/components/Cart.tsx
+++ b/fe/src/components/Cart.tsx
@@ -173,7 +173,7 @@ export default function Cart({ cartItems, removeItem, removeAllItems, changePage
         />
       )}
       {isCashPaymentModalOpen && (
-        <CashPaymentModal totalPrice={totalPrice} requestPayment={requestPayment} closeModal={closeCashPaymentModal} />
+        <CashPaymentModal totalPrice={totalPrice} requestPayment={requestPayment} changePage={changePage} closeModal={closeCashPaymentModal} />
       )}
       {isIndicatorVisible && <PaymentSpinner />}
     </section>

--- a/fe/src/components/Payment.tsx
+++ b/fe/src/components/Payment.tsx
@@ -43,10 +43,11 @@ export function PaymentSpinner() {
 interface CashPaymentModalProps {
   totalPrice: number;
   closeModal: () => void;
-  requestPayment: (inputAmount:number) => void;
+  requestPayment: (inputAmount:number) => Promise<ResponseBody>;
+  changePage: (path: Path, response: ResponseBody) => void;
 }
 
-export function CashPaymentModal({ totalPrice, closeModal, requestPayment }: CashPaymentModalProps) {
+export function CashPaymentModal({ totalPrice, closeModal, requestPayment, changePage }: CashPaymentModalProps) {
   const [inputAmount, setInputAmount] = useState(0);
   const [isPaymentButtonActive, setIsPaymentButtonActive] = useState(false);
 
@@ -66,9 +67,11 @@ export function CashPaymentModal({ totalPrice, closeModal, requestPayment }: Cas
     setInputAmount((i) => i + amount);
   };
 
-  const handleConfirmButtonClick = () => {
+  const handleConfirmButtonClick = async () => {
     setIsPaymentButtonActive(false);
-    requestPayment(inputAmount);
+    const response = await requestPayment(inputAmount);
+
+    changePage("/result", response);
   };
 
   return (


### PR DESCRIPTION
## 의도
현금 결제 요청 후 응답을 받아 결과 페이지로 이동하는 기능

## 구체적으로 봐야하는 포인트, 세부적인 변경점
- CashPaymentModal의 `handleConfirmButtonClick()`
- 현금 결제 요청의 응답 데이터를 받기
- 응답 데이터를 changePage()의 인자로 넘기며 result 페이지로 이동

## 관련 이슈
#63
